### PR TITLE
v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const entropy = require('./lib/entropy');
     let score = entropy(pass);
     console.log(`Entropy score for "${pass}":`, score.entropy);
     console.log(`  Unique characters : ${score.length}`);
-    console.log(`  Character classes : ${score.classNames}`);
+    console.log(`  Token sets: ${score.sets.join(', ')}`);
     if (score.acceptable) {
       if (score.ideal) {
         console.log(`Password is ideal.`);

--- a/lib/entropy.js
+++ b/lib/entropy.js
@@ -10,7 +10,7 @@ const TOKEN_CLASS_COMMON = 'common-password';
 const DEFAULT_CONFIGURATION = {
   minAcceptable: 64,
   minIdeal: 96,
-  characterClasses: 'all'
+  sets: 'all'
 }
 
 // Common Chinese words in both Traditional and Simplified Chinese
@@ -56,26 +56,26 @@ const	ENTROPY_CLASSES = [
     return codeToChar[c] && codeToChar[c].tokenClass === TOKEN_CLASS_COMMON;
   }},
   { score: Math.log(10), name: "number", range: [0x30, 0x39]},
-  { score: Math.log(26), name: "lower-roman", range: [0x61,0x7a]},
-  { score: Math.log(26), name: "upper-roman", range: [0x41,0x5a]},
+  { score: Math.log(26), name: "latin-small", range: [0x61,0x7a]},
+  { score: Math.log(26), name: "latin-capital", range: [0x41,0x5a]},
   // rated "10" because most languages only a small number of accented characters.
   // includes letters from Latin1 Supplement, Latins Extended A to E, IPA extensions,
   // and Latin Extended Additional
-  { score: Math.log(10), name: "extended-roman", 
+  { score: Math.log(10), name: "latin-extended", 
     range: [0xc0, 0xd6, 0xd8, 0xf6, 0xf8, 0x02af, 0x1e00, 0x1eff,
             0x2c60, 0x2c7f, 0xa720, 0xa7ff, 0xab30, 0xab6f]},
   { score: Math.log(12), name: "special", range: [0x21, 0x2f, 0x3a, 0x3f, 0x5b, 0x60]},
-  { score: Math.log(33), name: "upper-cyrillic", range: [0x410,0x42f]},
-  { score: Math.log(33), name: "lower-cyrillic", range: [0x430,0x44f]},
+  { score: Math.log(33), name: "cyrillic-capital", range: [0x410,0x42f]},
+  { score: Math.log(33), name: "cyrillic-small", range: [0x430,0x44f]},
   // includes letters from Cyrillic Supplements, Cyrillic Extended A, B, and C, 
   // and Cyrillic letters not included in upper-cyrillic or lower-cyrillic
-  { score: Math.log(10), name: "extended-cyrillic",
+  { score: Math.log(10), name: "cyrillic-extended",
     range: [0x400, 0x40f, 0x450, 0x52f, 0x2de0, 0x2dff, 0xa640, 0xa69f, 0x1c80, 0x1c8f]},
-  { score: Math.log(24), name: "lower-greek", range: [0x391,0x3a9]},
-  { score: Math.log(24), name: "upper-greek", range: [0x3b1,0x3c9]},
+  { score: Math.log(24), name: "greek-capital", range: [0x391,0x3a9]},
+  { score: Math.log(24), name: "greek-small", range: [0x3b1,0x3c9]},
   // includes a few unassigned code points so we only have to test one range
   // instead of 16
-  { score: Math.log(10), name: "extended-greek", range: [0x1f00, 0x1ff]},
+  { score: Math.log(10), name: "greek-extended", range: [0x1f00, 0x1ff]},
   { score: Math.log(40), name: "hiragana", range: [0x3041,0x3096]},
   { score: Math.log(40), name: "katakana", range: [0x30A0,0x30fa]},
   { score: Math.log(40), name: "bopomofo", range: [0x3105,0x312c,0x31a0,0x31b7]},
@@ -87,7 +87,7 @@ const	ENTROPY_CLASSES = [
     }
     return commonHanziSet.has(c);
   }},
-  { score: Math.log(1000), name: "hanzi", range: [0x4e00, 0x9fbf], cancel: ["commonhanzi"]},
+  { score: Math.log(1000), name: "hanzi", range: [0x4e00, 0x9fbf]},
   // unknown can cover "burred" latin, cyrillic, etc, so the
   // entropy is limited to 100.
   { score: Math.log(100), name: "unknown", test: (c) => {return true;}},
@@ -96,7 +96,7 @@ const	ENTROPY_CLASSES = [
 ];
 
 const ENTROPY_CLASS_ALIASES = {
-  western: ['common-passwords', 'lower-roman', 'upper-roman', 'number', 'special']
+  western: ['common-passwords', 'latin-capital','latin-small', 'number', 'special']
 }
 
 // suggested maximum scale for measuring entropy
@@ -291,10 +291,10 @@ function letterSet(str) {
  */
 function entropyClassAcceptable(name) {
   // nothing to do for 'all'
-  if ('all' === _configs.characterClasses) {
+  if ('all' === _configs.sets) {
     return true;
   }
-  let cccs = _configs.characterClasses;
+  let cccs = _configs.sets;
   'string' === typeof(cccs) && (cccs = [cccs]);
   
   for (let ccc of cccs) {
@@ -338,7 +338,7 @@ function passwordEntropy(_password) {
   let uniquePasswordLetters = letterSet(_password);
   let result = {
     classes: [], 
-    classNames: [],
+    sets: [],
     length: uniquePasswordLetters.size, 
     entropy: 0,
     max_entropy_scale: ENTROPY_SCALE_MAX
@@ -398,9 +398,9 @@ function passwordEntropy(_password) {
   }
 
   // now calculate the total entropy of the classes represented
-  result.classNames = Object.keys(classTally);
-  for (i = 0; i < result.classNames.length; i++) {
-    let tokenSet = ENTROPY_CLASSES.find(t => t.name === result.classNames[i]);
+  result.sets = Object.keys(classTally);
+  for (i = 0; i < result.sets.length; i++) {
+    let tokenSet = ENTROPY_CLASSES.find(t => t.name === result.sets[i]);
     result.entropy += tokenSet.score;
   }
   // total class entropy * number of tokens gives us the score

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ideal-password",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "description": "Password entropy test, loosely inspired by xkcd",
   "main": "index.js",
   "scripts": {

--- a/test/40-entropy.js
+++ b/test/40-entropy.js
@@ -42,25 +42,25 @@ describe('Entropy Calculation test', function() {
 
   it('entropy of a simple password', function() {
     expect(test1.length).to.be.equal(control.length);
-    expect(test1.classNames.length).to.be.equal(1);
+    expect(test1.sets.length).to.be.equal(1);
     expect(test1.entropy).to.be.equal(control.entropy);
     expect(test2.length).to.be.equal(control.length + 1);
-    expect(test2.classNames.length).to.be.equal(1);
+    expect(test2.sets.length).to.be.equal(1);
     expect(test2.entropy).to.be.greaterThan(control.entropy);
     expect(test3.length).to.be.equal(control.length + 1);
-    expect(test3.classNames.length).to.be.equal(2);
+    expect(test3.sets.length).to.be.equal(2);
     expect(test3.entropy).to.be.greaterThan(control.entropy);
     expect(test3.entropy).to.be.greaterThan(test1.entropy);
     expect(test4.length).to.be.equal(control.length + 1);
-    expect(test4.classNames.length).to.be.equal(3);
+    expect(test4.sets.length).to.be.equal(3);
     expect(test4.entropy).to.be.greaterThan(control.entropy);
     expect(test4.entropy).to.be.greaterThan(test1.entropy);
   });
   it('entropy with special characters', function() {
     let test = function(e) {
-      expect(e.classNames).to.include('special');
+      expect(e.sets).to.include('special');
       expect(e.length).to.be.equal(test2.length);
-      expect(e.classNames.length).to.be.equal(test3.classNames.length);
+      expect(e.sets.length).to.be.equal(test3.sets.length);
       expect(e.entropy).to.be.greaterThan(control.entropy);
       // because special is a larger character class than number
       expect(e.entropy).to.be.greaterThan(test3.entropy); 
@@ -71,9 +71,9 @@ describe('Entropy Calculation test', function() {
   });
   it('entropy with a complex emoji', function() {
     let test = function(e) {
-      expect(e.classNames).to.include('emoji');
+      expect(e.sets).to.include('emoji');
       expect(e.length).to.be.equal(test2.length);
-      expect(e.classNames.length).to.be.equal(test3.classNames.length);
+      expect(e.sets.length).to.be.equal(test3.sets.length);
       expect(e.entropy).to.be.greaterThan(control.entropy);
       // because emoji is a larger character class than number
       expect(e.entropy).to.be.greaterThan(test3.entropy); 
@@ -86,9 +86,9 @@ describe('Entropy Calculation test', function() {
   });
   it('entropy with hanzi, common and rarer', function() {
     let test = function(e, c) {
-      expect(e.classNames).to.include(c);
+      expect(e.sets).to.include(c);
       expect(e.length).to.be.equal(test2.length);
-      expect(e.classNames.length).to.be.equal(test3.classNames.length);
+      expect(e.sets.length).to.be.equal(test3.sets.length);
       expect(e.entropy).to.be.greaterThan(control.entropy);
       // because emoji is a larger character class than number
       expect(e.entropy).to.be.greaterThan(test3.entropy); 
@@ -103,23 +103,23 @@ describe('Entropy Calculation test', function() {
     expect(hanziTest3.entropy).to.be.greaterThan(hanziTest1.entropy);
 
     expect(hanziTest5.entropy).to.be.equal(hanziControl2.entropy);
-    expect(hanziTest5.classNames).to.include('hanzi');
-    expect(hanziTest5.classNames).to.not.include('common-hanzi');
+    expect(hanziTest5.sets).to.include('hanzi');
+    expect(hanziTest5.sets).to.not.include('common-hanzi');
     expect(hanziTest6.entropy).to.be.equal(hanziControl1.entropy);
-    expect(hanziTest6.classNames).to.not.include('hanzi');
-    expect(hanziTest6.classNames).to.include('common-hanzi');
+    expect(hanziTest6.sets).to.not.include('hanzi');
+    expect(hanziTest6.sets).to.include('common-hanzi');
   });
   it('entropy with a bad password', function() {
     expect(control.entropy).to.be.greaterThan(badPassword1.entropy);
     expect(badPassword2.entropy).to.be.equal(badPassword1.entropy);
     expect(control.entropy).to.be.greaterThan(badPassword3.entropy);
     expect(badPassword3.entropy).to.be.greaterThan(badPassword1.entropy);
-    expect(badPassword1.classNames.length).to.be.equal(1);
-    expect(badPassword2.classNames.length).to.be.equal(1);
-    expect(badPassword1.classNames).to.include('common-passwords');
-    expect(badPassword2.classNames).to.include('common-passwords');
-    expect(badPassword3.classNames).to.include('common-passwords');
-    expect(badPassword3.classNames).to.include('lower-roman');
+    expect(badPassword1.sets.length).to.be.equal(1);
+    expect(badPassword2.sets.length).to.be.equal(1);
+    expect(badPassword1.sets).to.include('common-passwords');
+    expect(badPassword2.sets).to.include('common-passwords');
+    expect(badPassword3.sets).to.include('common-passwords');
+    expect(badPassword3.sets).to.include('latin-small');
     expect(badPassword3.entropy).to.be.equal(badPassword4.entropy);
   });
 });

--- a/test/50-configs.js
+++ b/test/50-configs.js
@@ -39,29 +39,29 @@ describe('Entropy Configuration test', function() {
     e=entropy('passw⚽️rd');
     expect(e.legal).to.be.true;
 
-    entropy.config('characterClasses', ['lower-roman', 'emoji', 'common-passwords']);
+    entropy.config('sets', ['latin-small', 'emoji', 'common-passwords']);
     e=entropy('passw⚽️rd');
     expect(e.legal).to.be.true;
     e=entropy('paXXword');
     expect(e.legal).to.be.false;
 
-    entropy.config('characterClasses', ['lower-roman']);
+    entropy.config('sets', ['latin-small']);
     e=entropy('passw⚽️rd');
     expect(e.legal).to.be.false;
 
-    entropy.config('characterClasses', 'lower-roman');
-    e=entropy('passw⚽️rd');
-    expect(e.legal).to.be.false;
-    e=entropy('paxxword');
-    expect(e.legal).to.be.true;
-
-    entropy.config('characterClasses', 'western');
+    entropy.config('sets', 'latin-small');
     e=entropy('passw⚽️rd');
     expect(e.legal).to.be.false;
     e=entropy('paxxword');
     expect(e.legal).to.be.true;
 
-    entropy.config('characterClasses', ['western', 'emoji', 'common-passwords']);
+    entropy.config('sets', 'western');
+    e=entropy('passw⚽️rd');
+    expect(e.legal).to.be.false;
+    e=entropy('paxxword');
+    expect(e.legal).to.be.true;
+
+    entropy.config('sets', ['western', 'emoji', 'common-passwords']);
     e=entropy('passw⚽️rd');
     expect(e.legal).to.be.true;
     e=entropy('paxxword');
@@ -69,7 +69,7 @@ describe('Entropy Configuration test', function() {
     
     e=entropy('писанка');
     expect(e.legal).to.be.false;
-    entropy.config('characterClasses');
+    entropy.config('sets');
     e=entropy('писанка');
     expect(e.legal).to.be.true;
   });


### PR DESCRIPTION
Version 2.0 is be a breaking change in that some vocabulary will change for
semantic accuracy and to more closely match Unicode Consortiums's use of
language:

* `roman` becomes `latin`
* `upper-roman` becomes `latin-capital`
* `lower-roman` becomes `latin-small`
* `extended-roman` becomes `latin-extended`
* `upper-greek` becomes `greek-capital`
* `lower-greek` becomes `greek-small`
* `extended-greek` becomes `greek-extended`
* `upper-cyrillic` becomes `cyrillic-capital`
* `lower-cyrillic` becomes `cyrillic-small`
* `extended-cyrillic` becomes `cyrillic-extended`
* `common-hanzi` becomes `hanzi-common`

However `common-passwords` will remain as `common-passwords`

Also "classes" become "sets" and most "characters" become "tokens".
The output object also changed in that now `classNames` are `sets`.